### PR TITLE
ci: add Dependabot Nix updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "nix"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- enable Dependabot version updates for Nix flakes
- let Dependabot maintain `flake.lock` inputs on a weekly schedule
- remove the old `DeterminateSystems/update-flake-lock` automation to avoid duplicate lockfile PRs

## Context
GitHub now supports Nix flakes in Dependabot version updates:
https://github.blog/changelog/2026-04-07-dependabot-version-updates-now-support-the-nix-ecosystem/

## Validation
- `git diff --check`
- verified every active flake repo has a `nix` Dependabot entry
- verified no `DeterminateSystems/update-flake-lock`, `update_flake_lock`, or `update-flake-lock` references remain


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Dependabot to update Nix flake inputs weekly and remove the `DeterminateSystems/update-flake-lock` workflow to avoid duplicate lockfile PRs.

- **Dependencies**
  - Add `.github/dependabot.yml` for `nix` ecosystem with a weekly schedule.
  - Remove `DeterminateSystems/update-flake-lock` to prevent duplicate `flake.lock` PRs.

<sup>Written for commit fa90c73a3794bf852bc3482d8fe04617eb55e65e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

